### PR TITLE
[FEATURE] 지역 즐겨찾기 테이블 API 작업

### DIFF
--- a/app/api/region-favorite/[user_id]/route.ts
+++ b/app/api/region-favorite/[user_id]/route.ts
@@ -9,7 +9,7 @@ type Params = {
 };
 
 export async function GET(_: NextRequest, { params }: Params) {
-  const user_id = decodeURIComponent(params.user_id);
+  const { user_id } = await params;
 
   try {
     const favorites = await GetByUserIdRegionUsecase(SbRegionFavoriteRepository(), user_id);

--- a/app/api/region-favorite/[user_id]/route.ts
+++ b/app/api/region-favorite/[user_id]/route.ts
@@ -1,0 +1,20 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { GetByUserIdRegionUsecase } from '@/application/usecases/regionFavorite/GetByUserIdRegionUsecase';
+import { SbRegionFavoriteRepository } from '@/infra/repositories/supabase/SbRegionFavoriteRepository';
+
+type Params = {
+  params: {
+    user_id: string;
+  };
+};
+
+export async function GET(_: NextRequest, { params }: Params) {
+  const user_id = decodeURIComponent(params.user_id);
+
+  try {
+    const favorites = await GetByUserIdRegionUsecase(SbRegionFavoriteRepository(), user_id);
+    return NextResponse.json(favorites);
+  } catch (error: any) {
+    return NextResponse.json({ error: error.message }, { status: 400 });
+  }
+}

--- a/app/api/region-favorite/route.ts
+++ b/app/api/region-favorite/route.ts
@@ -1,0 +1,47 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { CreateRegionFavoriteUsecase } from '@/application/usecases/regionFavorite/CreateRegionFavoriteUsecase';
+import { DeleteRegionFavoriteUsecase } from '@/application/usecases/regionFavorite/DeleteRegionFavoriteUsecase';
+import { UpdateRegionFavoriteUsecase } from '@/application/usecases/regionFavorite/UpdateRegionFavoriteUsecase';
+import { SbRegionFavoriteRepository } from '@/infra/repositories/supabase/SbRegionFavoriteRepository';
+
+export async function POST(req: NextRequest) {
+  const data = await req.json();
+
+  try {
+    const updatedFavorites = await CreateRegionFavoriteUsecase(
+      SbRegionFavoriteRepository(),
+      data
+    );
+    return NextResponse.json(updatedFavorites);
+  } catch (error: any) {
+    return NextResponse.json({ error: error.message }, { status: 400 });
+  }
+}
+
+export async function DELETE(req: NextRequest) {
+  const dto = await req.json();
+
+  try {
+    const updatedFavorites = await DeleteRegionFavoriteUsecase(
+      SbRegionFavoriteRepository(),
+      dto
+    );
+    return NextResponse.json(updatedFavorites);
+  } catch (error: any) {
+    return NextResponse.json({ error: error.message }, { status: 400 });
+  }
+}
+
+export async function PATCH(req: NextRequest) {
+  const data = await req.json();
+
+  try {
+    const updatedFavorites = await UpdateRegionFavoriteUsecase(
+      SbRegionFavoriteRepository(),
+      data
+    );
+    return NextResponse.json(updatedFavorites);
+  } catch (error: any) {
+    return NextResponse.json({ error: error.message }, { status: 400 });
+  }
+}

--- a/application/usecases/regionFavorite/CreateRegionFavoriteUsecase.ts
+++ b/application/usecases/regionFavorite/CreateRegionFavoriteUsecase.ts
@@ -1,0 +1,13 @@
+import { UserRegionFavorite } from '@/domain/entities/UserRegionFavorite';
+import { RegionFavoriteRepogitory } from '@/domain/repositories/RegionFavoriteRepository';
+
+export const CreateRegionFavoriteUsecase = async (
+  regionFavoriteRepository: RegionFavoriteRepogitory,
+  data: UserRegionFavorite,
+): Promise<UserRegionFavorite[]> => {
+  const created = await regionFavoriteRepository.create(data);
+  if (!created) throw new Error('즐겨찾기 생성에 실패했습니다.');
+  const updated = await regionFavoriteRepository.getByUserId(data.user_id);
+  if (!updated) throw new Error('즐겨찾기 불러오기를 실패했습니다.');
+  return updated;
+};

--- a/application/usecases/regionFavorite/DeleteRegionFavoriteUsecase.ts
+++ b/application/usecases/regionFavorite/DeleteRegionFavoriteUsecase.ts
@@ -1,0 +1,16 @@
+import { UserRegionFavorite } from '@/domain/entities/UserRegionFavorite';
+import { RegionFavoriteRepogitory } from '@/domain/repositories/RegionFavoriteRepository';
+import { RegionFavoriteRequestDto } from './dto/RegionFavoriteDto';
+
+export const DeleteRegionFavoriteUsecase = async (
+  regionFavoriteRepository: RegionFavoriteRepogitory,
+  dto: RegionFavoriteRequestDto,
+): Promise<UserRegionFavorite[]|null> => {
+  const deleted = await regionFavoriteRepository.delete(dto);
+  if (!deleted) throw new Error('즐겨찾기 삭제에 실패했습니다.');
+
+  const updated = await regionFavoriteRepository.getByUserId(dto.user_id);
+  if (updated === null) throw new Error('즐겨찾기 불러오기를 실패했습니다.');
+  
+  return updated;
+};

--- a/application/usecases/regionFavorite/GetByUserIdRegionUsecase.ts
+++ b/application/usecases/regionFavorite/GetByUserIdRegionUsecase.ts
@@ -1,0 +1,12 @@
+import { UserRegionFavorite } from '@/domain/entities/UserRegionFavorite';
+import { RegionFavoriteRepogitory } from '@/domain/repositories/RegionFavoriteRepository';
+
+export const GetByUserIdRegionUsecase = async (
+  regionFavoriteRepository: RegionFavoriteRepogitory,
+  user_id: string,
+): Promise<UserRegionFavorite[]|null> => {
+  const favorites = await regionFavoriteRepository.getByUserId(user_id);
+  if (favorites===null) throw new Error('즐겨찾기 조회에 실패했습니다.');
+  
+  return favorites;
+};

--- a/application/usecases/regionFavorite/UpdateRegionFavoriteUsecase.ts
+++ b/application/usecases/regionFavorite/UpdateRegionFavoriteUsecase.ts
@@ -1,0 +1,13 @@
+import { UserRegionFavorite } from '@/domain/entities/UserRegionFavorite';
+import { RegionFavoriteRepogitory } from '@/domain/repositories/RegionFavoriteRepository';
+
+export const UpdateRegionFavoriteUsecase = async (
+  regionFavoriteRepository: RegionFavoriteRepogitory,
+  data: UserRegionFavorite,
+): Promise<UserRegionFavorite[]> => {
+  const created = await regionFavoriteRepository.update(data);
+  if (!created) throw new Error('즐겨찾기 수정에 실패했습니다.');
+  const updated = await regionFavoriteRepository.getByUserId(data.user_id);
+  if (!updated) throw new Error('즐겨찾기 불러오기를 실패했습니다.');
+  return updated;
+};

--- a/application/usecases/regionFavorite/dto/RegionFavoriteDto.ts
+++ b/application/usecases/regionFavorite/dto/RegionFavoriteDto.ts
@@ -1,0 +1,5 @@
+export interface RegionFavoriteRequestDto {
+  user_id: string;
+  region_id: string;
+}
+

--- a/domain/repositories/RegionFavoriteRepository.ts
+++ b/domain/repositories/RegionFavoriteRepository.ts
@@ -1,0 +1,9 @@
+import { RegionFavoriteRequestDto } from "@/application/usecases/regionFavorite/dto/RegionFavoriteDto";
+import { UserRegionFavorite } from "../entities/UserRegionFavorite";
+
+export interface RegionFavoriteRepogitory {
+  create(resionFavoriteData:UserRegionFavorite): Promise<UserRegionFavorite>;
+  delete(resionFavoriteDto: RegionFavoriteRequestDto): Promise<UserRegionFavorite>;
+  update(resionFavoriteData: UserRegionFavorite): Promise<UserRegionFavorite>;
+  getByUserId(user_id: string): Promise<UserRegionFavorite[]|null>;
+}

--- a/infra/repositories/supabase/SbRegionFavoriteRepository.ts
+++ b/infra/repositories/supabase/SbRegionFavoriteRepository.ts
@@ -1,0 +1,51 @@
+import { RegionFavoriteRepogitory } from '@/domain/repositories/RegionFavoriteRepository';
+import { supabase } from './Sbclient';
+
+export const SbRegionFavoriteRepository = (): RegionFavoriteRepogitory => ({
+  async create(resionFavoriteData) {
+    const { data, error } = await supabase
+      .from('user_region_favorite')
+      .insert(resionFavoriteData)
+      .select()
+      .single();
+
+    if (error || !data) throw new Error('지역 즐겨찾기 생성 실패');
+
+    return data;
+  },
+  async delete(resionFavoriteDto) {
+    const { data, error } = await supabase
+      .from('user_region_favorite')
+      .delete()
+      .eq('user_id', resionFavoriteDto.user_id)
+      .eq('region_id', resionFavoriteDto.region_id)
+      .select()
+      .single();
+
+    if (error || !data) throw new Error('지역 즐겨찾기 삭제 실패');
+
+    return data;
+  },
+  async update(resionFavoriteData) {
+    const { data, error } = await supabase
+      .from('user_region_favorite')
+      .update({ is_primary: resionFavoriteData.is_primary })
+      .eq('user_id', resionFavoriteData.user_id)
+      .eq('region_id', resionFavoriteData.region_id)
+      .select()
+      .single();
+
+    if (error || !data) throw new Error('지역 즐겨찾기 수정 실패');
+
+    return data;
+  },
+  async getByUserId(user_id) {
+    const { data, error } = await supabase
+      .from('user_region_favorite')
+      .select('*')
+      .eq('user_id', user_id);
+
+    if (error) throw new Error('유저 아이디로 지역 즐겨찾기 검색 실패');
+    return data ?? [];
+  },
+});


### PR DESCRIPTION
## 📝 작업 내용

- 지역 즐겨찾기 추가 / 삭제 / 업데이트 (is_primary 정보 변경) API 작업
- user_id 로 모든 즐겨찾기 가져오기 작업 API 작업

## 💬 리뷰 요구사항

- 한 사람당 즐겨찾기는 3개만 추가 가능하고 , 대표 지역은 하나만 가능하도록 프론트에서 처리 필요
- 수정해야 할 부분이 있다면 말씀해주세요! :)

## ⛓️ 관련 이슈
#35
